### PR TITLE
Fix TypeError: null studentCourses in checkCoursePurchaseInfo line 99

### DIFF
--- a/server/controllers/student-controller/course-controller.js
+++ b/server/controllers/student-controller/course-controller.js
@@ -96,7 +96,7 @@ const checkCoursePurchaseInfo = async (req, res) => {
     });
 
     const ifStudentAlreadyBoughtCurrentCourse =
-      studentCourses.courses.findIndex((item) => item.courseId === id) > -1;
+      studentCourses?.courses.findIndex((item) => item.courseId === id) > -1;
     res.status(200).json({
       success: true,
       data: ifStudentAlreadyBoughtCurrentCourse,


### PR DESCRIPTION
This PR fixes a TypeError that occurred when attempting to access `courses` from `null` in the checkCoursePurchaseInfo function. Added optional chaining to handle missing data gracefully.